### PR TITLE
Small cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ Gitodo supports sublists inside lists, as well as list/sublist creation, checkin
 - [x] Viewing a List
 `gitodo show FileName`
 
-- [x] Viewing only undone todos:   
+- [x] Viewing only uncompleted todos:
 `gitodo show FileName --open`
 
-- [x] Viewing only undone todos:   
+- [x] Viewing only completed todos:
 `gitodo show FileName --done`
 
 #### The -f flag
@@ -38,7 +38,7 @@ If you could like a command to pertain to a sublist only during either `show` or
 
 **Example**: `gitodo show FileName -s "Sublist Name" `
 
-If you would like to create a new Todo List with a sublist you can add the -s flag to add a the default **General** sublist to the file. You can also add an argument after the -s flag to provide a custom sublist name. 
+If you would like to create a new Todo List with a sublist you can add the -s flag to add the default **General** sublist to the file. You can also add an argument after the -s flag to provide a custom sublist name.
 
 **Example**: `gitodo create FileName -s //adds General sublist`
 

--- a/README.md
+++ b/README.md
@@ -3,25 +3,25 @@
 ================
 
 ###What is it?
-Gitodo is a simple CLI utility to manage todo list items, using a github repo as the datastore. Todo lists are stored and managed in markdown files. 
+Gitodo is a simple CLI utility to manage todo list items, using a github repo as the datastore. Todo lists are stored and managed in markdown files.
 
-Gitodo supports sublists inside lists, as well as list/sublist creation, checking off items, listing items, and searching. 
+Gitodo supports sublists inside lists, as well as list/sublist creation, checking off items, listing items, and searching.
 
 ###Usage
 
-- [x] Create a new list    
+- [x] Create a new list
 `gitodo create FileName`
 
-- [X] Add a new Todo to a list    
+- [X] Add a new Todo to a list
 `gitodo todo FileName "Take Over The World"`
 
-- [x] Checking off a todo item  
+- [x] Checking off a todo item
 `gitodo complete FileName "Take Over The World" `
 
-- [x] Creating a sublist:  
+- [x] Creating a sublist:
 `gitodo sublist FileName "Sublist Name"`
 
-- [x] Viewing a List  
+- [x] Viewing a List
 `gitodo show FileName`
 
 - [x] Viewing only undone todos:   
@@ -31,10 +31,10 @@ Gitodo supports sublists inside lists, as well as list/sublist creation, checkin
 `gitodo show FileName --done`
 
 #### The -f flag
-By default Gitodo will throw errors if you attempt to add a todo to a file that does not exist, or to a sublist that does not exist in a file. Adding the -f flag, (or --force) will suppress the errors and create the file or sublist as necessary. 
+By default Gitodo will throw errors if you attempt to add a todo to a file that does not exist, or to a sublist that does not exist in a file. Adding the -f flag, (or --force) will suppress the errors and create the file or sublist as necessary.
 
 #### The -s flag
-If you could like a command to pertain to a sublist only during either `show` or `todo` commands, you may add the -s flag with the list name to follow.   
+If you could like a command to pertain to a sublist only during either `show` or `todo` commands, you may add the -s flag with the list name to follow.
 
 **Example**: `gitodo show FileName -s "Sublist Name" `
 
@@ -42,12 +42,12 @@ If you would like to create a new Todo List with a sublist you can add the -s fl
 
 **Example**: `gitodo create FileName -s //adds General sublist`
 
-**With Custom Sublist:**  `gitodo create FileName -s "My Nifty List Name"` 
+**With Custom Sublist:**  `gitodo create FileName -s "My Nifty List Name"`
 
 ### The -h flag
-By default gitodo will create a commit for each write action. These are triggered on `create`, `todo`,  `complete`, and `sublist` commands. If you would like to hold a group of changes to be committed at once, you can use the -h flag ( or --hold). The next writeable command will commit all the previously held commands into a single commit. 
+By default gitodo will create a commit for each write action. These are triggered on `create`, `todo`,  `complete`, and `sublist` commands. If you would like to hold a group of changes to be committed at once, you can use the -h flag ( or --hold). The next writeable command will commit all the previously held commands into a single commit.
 
-**Example**  
+**Example**
 
 ```
 gitodo todo TestList "some cool Todo" -h
@@ -56,22 +56,22 @@ gitodo create NewList -s "Nifty Sublist" // This will commit itself and the two 
 ```
 
 ###Installation
-Make gitodo executable, and move to a useable place. 
+Make gitodo executable, and move to a useable place.
 
 ```
 chmod +x gitodo && mv gitodo /usr/local/bin/
 ```
 
-Gitodo is not able to be used from inside any git repo you like. 
+Gitodo is not able to be used from inside any git repo you like.
 
 ###Upcoming Features
 
-- [ ] Support for Due Dates 
+- [ ] Support for Due Dates
 
-- [ ] View due todos  
+- [ ] View due todos
 `gitodo show --due`
 
-- [ ] View past due todos  
-`gitodo show --past-due` 
-- [ ] Add multiple, todos at once   
+- [ ] View past due todos
+`gitodo show --past-due`
+- [ ] Add multiple, todos at once
 - [x] Warn when todo already exists

--- a/gitodo
+++ b/gitodo
@@ -50,7 +50,7 @@ function flag_exists()
 
 function create_sublist_from_flag()
 {
-	content=$(cat "${a[1]}.md")
+	content=$(<"${a[1]}.md")
 	if flag_exists "-s"; then
 		find_flag_index "-s"
 		if [ -z "${a[$idx]}" ]; then
@@ -87,7 +87,7 @@ function todo_exists()
 
 function add_todo()
 {
-	content=$(cat "${a[1]}.md")
+	content=$(<"${a[1]}.md")
 	if todo_exists "$1"; then
 		if flag_exists "-f" || flag_exists "--force"; then
 			echo "- [ ] $1" >> $2.md
@@ -164,7 +164,7 @@ function sublist()
 	if [ -z ${a[1]} ] || [ -z "${a[2]}" ]; then
 		error "Filename and sublist must be specified"
 	elif [ -a "${a[1]}.md" ]; then
-		content=$(cat "${a[1]}.md")
+		content=$(<"${a[1]}.md")
 		if sublist_exists ${a[2]}; then
 			if flag_exists "-f" || flag_exists "--force"; then
 				create_sublist "${a[2]}" ${a[1]}

--- a/gitodo
+++ b/gitodo
@@ -220,7 +220,7 @@ function write()
 		commit_message=$(<"${TMPFILE}")
 		rm ${TMPFILE}
 		response=$(git pull origin master)
-		response=$(git add --all && git commit -m "$commit_message" && git push origin master)
+		response=$(git add --all && git commit -m "${commit_message}" && git push origin master)
 	fi
 }
 

--- a/gitodo
+++ b/gitodo
@@ -71,9 +71,9 @@ function create()
 		error "File name must be specified"
 	elif [ -a "${a[1]}.md" ]; then
 		error "Requested File already exists."
-	else
-		create_file ${a[1]}
 	fi
+	file_is_in_gitdir
+	create_file ${a[1]}
 }
 
 function todo_exists()
@@ -132,22 +132,18 @@ function todo_is_complete()
 
 function complete()
 {
-	if [ -a "${a[1]}.md" ]; then
-		content=$(cat "${a[1]}.md")
-		if todo_exists "${a[2]}"; then
-			if todo_is_complete "${a[2]}"; then
-				error "Todo is already complete"
-			else
-				echo "${content/"- [ ] ${a[2]}"/- [x] ${a[2]} }" > "${a[1]}.md"
-				success "${a[2]} marked as complete"
-			fi
+  file_exists
+	content=$(<"${a[1]}.md")
+	if todo_exists "${a[2]}"; then
+		if todo_is_complete "${a[2]}"; then
+			error "Todo is already complete"
 		else
-			error "Todo ${a[2]} does not exist"
+			echo "${content/"- [ ] ${a[2]}"/- [x] ${a[2]} }" > "${a[1]}.md"
+			success "${a[2]} marked as complete"
 		fi
 	else
-		error "Requested List '${a[1]}' does not exist"
+		error "Todo ${a[2]} does not exist"
 	fi
-
 }
 
 function sublist_exists()
@@ -207,17 +203,15 @@ function should_be_shown()
 
 function show()
 {
-	if [ -z ${a[1]} ]; then
-    		error "Filename must be specified"
-	elif [ -a "${a[1]}.md" ]; then
-		while read line; do
-			if should_be_shown "$line"; then
-	            echo "$line"
-			fi
-        done < ${a[1]}.md
-	else
-		error "Requested File ${a[1]} doesn't exist"
+	if [ -z "${a[1]}" ]; then
+		error "Filename must be specified"
 	fi
+	file_exists
+	while read line; do
+		if should_be_shown "$line"; then
+			echo "$line"
+		fi
+	done < "${a[1]}.md"
 }
 
 function write()
@@ -228,6 +222,31 @@ function write()
 		response=$(git pull origin master)
 		response=$(git add --all && git commit -m "$commit_message" && git push origin master)
 	fi
+}
+
+# This checks that the directory your todo file is in is the same as
+# the git repository that you are currently working in. It does *not*
+# check that the todo file actually exists, that is handled by file_exists()
+function file_is_in_gitdir()
+{
+  file_name=$(readlink -f "${a[1]}.md")
+  directory=$(dirname "$file_name")
+  git_repo=$(git rev-parse --show-toplevel)
+  if [[ ! $directory =~ $git_repo ]]; then
+    error "Todo file must be located within the current git repo: ${git_repo}"
+  fi
+}
+
+# Check to see if the file containing your todo list exists and exits the script
+# with an error if it does not. As such, it is not suitable for use any time the
+# file existing is not a fatal error.
+function file_exists()
+{
+  if [[ ! -a ${a[1]}.md ]]; then
+    error "Requested list ${a[1]} doesn't exist"
+  fi
+  file_is_in_gitdir # We should also check this whenever we're looking to see if
+                    # the file exists, though not vice-versa
 }
 
 a=("$@")

--- a/gitodo
+++ b/gitodo
@@ -272,6 +272,13 @@ case $1 in
 		show
 		;;
 	*)
-		echo $"Usage: $0 {create|add|complete|show|todo}"
+		echo $"Usage: $0 <create|todo|complete|show|sublist> [--open | --done]"
+		echo ""
+		echo "Examples:"
+		echo "         gitodo create MyFile"
+		echo "         gitodo todo MyFile 'Take Over The World'"
+		echo "         gitodo show MyFile --open"
+		echo "         gitodo complete MyFile 'Take Over The World'"
+		echo "         gitodo sublist MyFile 'Sublist Name'"
 		exit 0
 esac

--- a/gitodo
+++ b/gitodo
@@ -116,7 +116,7 @@ function todo()
 			create_sublist_from_flag ${a[1]}
 			add_todo "${a[2]}" ${a[1]}
 		else
-			error "File does not exist. To force file creation, add the -f Flag"
+			error "File does not exist. To force file creation, add the -f flag"
 		fi
 	fi
 }

--- a/gitodo
+++ b/gitodo
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+TMPFILE=$(mktemp /tmp/gitodo.XXXXXX)
+trap 'rm -f $TMPFILE' EXIT
+
 function error()
 {
 	echo "Error: $1"
@@ -9,7 +12,7 @@ function error()
 function success()
 {
 	echo $1
-	echo "$commit_message$1" >> gitodo.tmpfile
+	echo "${commit_message}$1" >> ${TMPFILE}
 }
 
 create_file()
@@ -220,8 +223,8 @@ function show()
 function write()
 {
 	if ! flag_exists "-h" && ! flag_exists "--hold"; then
-		commit_message=$(cat "gitodo.tmpfile")
-		rm gitodo.tmpfile
+		commit_message=$(<"${TMPFILE}")
+		rm ${TMPFILE}
 		response=$(git pull origin master)
 		response=$(git add --all && git commit -m "$commit_message" && git push origin master)
 	fi

--- a/gitodo
+++ b/gitodo
@@ -72,7 +72,7 @@ function create()
 	elif [ -a "${a[1]}.md" ]; then
 		error "Requested File already exists."
 	fi
-	file_is_in_gitdir
+	confirm_file_is_in_gitdir
 	create_file ${a[1]}
 }
 
@@ -132,7 +132,7 @@ function todo_is_complete()
 
 function complete()
 {
-  file_exists
+  confirm_file_exists
 	content=$(<"${a[1]}.md")
 	if todo_exists "${a[2]}"; then
 		if todo_is_complete "${a[2]}"; then
@@ -206,7 +206,7 @@ function show()
 	if [ -z "${a[1]}" ]; then
 		error "Filename must be specified"
 	fi
-	file_exists
+	confirm_file_exists
 	while read line; do
 		if should_be_shown "$line"; then
 			echo "$line"
@@ -226,8 +226,8 @@ function write()
 
 # This checks that the directory your todo file is in is the same as
 # the git repository that you are currently working in. It does *not*
-# check that the todo file actually exists, that is handled by file_exists()
-function file_is_in_gitdir()
+# check that the todo file actually exists, that is handled by confirm_file_exists()
+function confirm_file_is_in_gitdir()
 {
   file_name=$(readlink -f "${a[1]}.md")
   directory=$(dirname "$file_name")
@@ -240,12 +240,12 @@ function file_is_in_gitdir()
 # Check to see if the file containing your todo list exists and exits the script
 # with an error if it does not. As such, it is not suitable for use any time the
 # file existing is not a fatal error.
-function file_exists()
+function confirm_file_exists()
 {
   if [[ ! -a ${a[1]}.md ]]; then
     error "Requested list ${a[1]} doesn't exist"
   fi
-  file_is_in_gitdir # We should also check this whenever we're looking to see if
+  confirm_file_is_in_gitdir # We should also check this whenever we're looking to see if
                     # the file exists, though not vice-versa
 }
 


### PR DESCRIPTION
Mostly small things to help cleanup the script and README a bit. I tried to split them up into separate commits so that you could review/reject them without having to go through everything at once. Some of them - like the trailing spaces - I fully admit have no functional value but make it look cleaner in my editor. Feel free to tell me to take a hike :grinning:

Oh, and the reference to `add` was in the help output, which I replaced with a reference to `sublist` instead.
